### PR TITLE
#164494422: Fix issues with cloudinary configuration

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { CloudinaryModule } from '@cloudinary/angular-5.x';
-import * as Cloudinary from 'cloudinary-core';
+import { Cloudinary as CloudinaryCore } from 'cloudinary-core';
 
 import { AngularMaterialModule } from './angular-material.module';
 import { AppComponent } from './app.component';
@@ -12,6 +12,10 @@ import { ArticlesService } from '../../src/services/articles.service';
 import { HomeComponent } from './home/home.component';
 import { HttpClientModule } from '@angular/common/http';
 import { TruncatePipe } from '../pipes/truncate.pipe';
+
+export const cloudinary = {
+  Cloudinary: CloudinaryCore
+};
 
 @NgModule({
   declarations: [
@@ -25,7 +29,7 @@ import { TruncatePipe } from '../pipes/truncate.pipe';
     AppRoutingModule,
     BrowserAnimationsModule,
     BrowserModule,
-    CloudinaryModule.forRoot(Cloudinary, { cloud_name: 'iyikuyoro'}),
+    CloudinaryModule.forRoot(cloudinary, { cloud_name: 'iyikuyoro'}),
     HttpClientModule
   ],
   providers: [


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the issues with cloudinary causing the application not to render.

#### Description of Task to be completed?
- [x] Adjust the implementation of the cloudinary module in the app module

#### How should this be manually tested?
- Clone the repo and checkout `bg-fix-rendering-164494422`
- Run `npm run heroku-postbuild`
- Run `npm run start`
- Navigate to `localhost:8080` on your browser and see if the application loads.

#### What are the relevant pivotal tracker stories?
#164494422

#### Screenshots
![image](https://user-images.githubusercontent.com/30635021/54032007-b51ae900-41b0-11e9-8f7c-b62919459a28.png)
